### PR TITLE
Add option to use prerelease version or not

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,21 @@ let package = Package(
             name: "mint-update",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "MintKit", package: "Mint"),
+                "MintUpdateUtil"
+            ]
+        ),
+        .target(
+            name: "MintUpdateUtil",
+            dependencies: [
                 .product(name: "MintKit", package: "Mint")
             ]
         ),
+        .testTarget(
+            name: "MintUpdateTests",
+            dependencies: [
+                "MintUpdateUtil"
+            ]
+        )
     ]
 )

--- a/Sources/MintUpdateUtil/Mint+.swift
+++ b/Sources/MintUpdateUtil/Mint+.swift
@@ -1,79 +1,15 @@
-import Foundation
-import ArgumentParser
+//
+//  Mint+.swift
+//
+//
+//  Created by p-x9 on 2024/09/18
+//  
+//
+
 import MintKit
-import PathKit
 import SwiftCLI
 
-@main
-struct mint_update: ParsableCommand {
-    static let configuration: CommandConfiguration = .init(
-        commandName: "mint-update",
-        abstract: "Updates version of the package defined in the `Mintfile`",
-        shouldDisplay: true,
-        helpNames: [.long, .short]
-    )
-
-    @ArgumentParser.Option(
-        help: "Package Name"
-    )
-    var name: String?
-
-    @ArgumentParser.Flag(
-        name: .customLong("all"),
-        help: "Update All Packages"
-    )
-    var shouldUpdateAll: Bool = false
-
-    @ArgumentParser.Option(
-        name: [.customShort("m"), .customLong("mintfile")],
-        help: "Custom path to a Mintfile."
-    )
-    var mintFile: String = "Mintfile"
-
-    @ArgumentParser.Flag(
-        name: .customLong("prerelease"),
-        help: "Use the Prerelease version. (alpha, beta, ...)"
-    )
-    var usePrerelease: Bool = false
-
-    mutating func run() throws {
-        let mint = Mint(
-            path: mintPath,
-            linkPath: linkPath,
-            mintFilePath: .init(mintFile)
-        )
-
-        if shouldUpdateAll {
-            try mint.updateAll(usePrerelease: usePrerelease)
-        } else if let name {
-            try mint.update(name, usePrerelease: usePrerelease)
-        } else {
-            print(
-                Self.helpMessage()
-            )
-            throw "Please specify package name"
-        }
-    }
-}
-
-extension mint_update {
-    var mintPath: Path {
-        var mintPath: Path = "~/.mint"
-        if let path = ProcessInfo.processInfo.environment["MINT_PATH"], !path.isEmpty {
-            mintPath = Path(path)
-        }
-        return mintPath
-    }
-
-    var linkPath: Path {
-        var linkPath: Path = "~/.mint/bin"
-        if let path = ProcessInfo.processInfo.environment["MINT_LINK_PATH"], !path.isEmpty {
-            linkPath = Path(path)
-        }
-        return linkPath
-    }
-}
-
+// MARK: - Package
 extension Mint {
     struct Package {
         let repo: String
@@ -83,9 +19,21 @@ extension Mint {
             "\(repo)@\(version)"
         }
     }
+
+    func packages(for mintfile: Mintfile) -> [PackageReference] {
+        var mintfile = mintfile
+        return withUnsafePointer(to: &mintfile) { ptr in
+            let raw = UnsafeRawPointer(ptr)
+            return raw.load(as: [PackageReference].self)
+        }
+    }
+}
+
+// MARK: - Update
+extension Mint {
     typealias MintfileReplacement = (from: Package, to: Package)
 
-    func updateAll(usePrerelease: Bool) throws {
+    package func updateAll(usePrerelease: Bool) throws {
         guard mintFilePath.exists,
               let mintfile = try? Mintfile(path: mintFilePath) else {
             throw "🌱 mintfile not exists"
@@ -98,7 +46,7 @@ extension Mint {
         try updateMintfile(replacements)
     }
 
-    func update(_ name: String, usePrerelease: Bool) throws {
+    package func update(_ name: String, usePrerelease: Bool) throws {
         guard mintFilePath.exists,
               let mintfile = try? Mintfile(path: mintFilePath) else {
             throw "🌱 mintfile not exists"
@@ -151,16 +99,8 @@ extension Mint {
     }
 }
 
-extension Mint {
-    func packages(for mintfile: Mintfile) -> [PackageReference] {
-        var mintfile = mintfile
-        return withUnsafePointer(to: &mintfile) { ptr in
-            let raw = UnsafeRawPointer(ptr)
-            return raw.load(as: [PackageReference].self)
-        }
-    }
-}
 
+// MARK: - Find Version
 extension Mint {
     func findLatestVersion(
         for package: PackageReference,
@@ -188,24 +128,5 @@ extension Mint {
         tags.sort { $0.compare($1, options: .numeric) == .orderedAscending }
 
         return tags.last
-    }
-}
-
-extension String {
-    static let prereleasePattern = #"^\d+\.\d+\.\d*[.-][A-Za-z0-9.-]+$"#
-    static var prereleaseRegex: NSRegularExpression {
-        try! .init(pattern: prereleasePattern)
-    }
-
-    var isPrerelease: Bool {
-        let range = NSRange(startIndex ..< endIndex, in: self)
-        return Self.prereleaseRegex
-            .firstMatch(in: self, options: [], range: range) != nil
-    }
-}
-
-extension String: LocalizedError {
-    public var errorDescription: String? {
-        self
     }
 }

--- a/Sources/MintUpdateUtil/String+.swift
+++ b/Sources/MintUpdateUtil/String+.swift
@@ -1,0 +1,28 @@
+//
+//  String+.swift
+//  
+//
+//  Created by p-x9 on 2024/09/18
+//  
+//
+
+import Foundation
+
+extension String {
+    static let prereleasePattern = #"^\d+\.\d+\.\d+[.+-][A-Za-z0-9.+-]+$"#
+    static var prereleaseRegex: NSRegularExpression {
+        try! .init(pattern: prereleasePattern)
+    }
+
+    package var isPrerelease: Bool {
+        let range = NSRange(startIndex ..< endIndex, in: self)
+        return Self.prereleaseRegex
+            .firstMatch(in: self, options: [], range: range) != nil
+    }
+}
+
+extension String: LocalizedError {
+    public var errorDescription: String? {
+        self
+    }
+}

--- a/Sources/mint-update/mint_update.swift
+++ b/Sources/mint-update/mint_update.swift
@@ -32,7 +32,7 @@ struct mint_update: ParsableCommand {
 
     @ArgumentParser.Flag(
         name: .customLong("use-prerelease"),
-        help: "Use the Prerelease version. (alpha, beta, ...)"
+        help: "Use the prerelease version. (alpha, beta, ...)"
     )
     var usePrerelease: Bool = false
 

--- a/Sources/mint-update/mint_update.swift
+++ b/Sources/mint-update/mint_update.swift
@@ -1,0 +1,75 @@
+import Foundation
+import ArgumentParser
+import MintKit
+import PathKit
+import MintUpdateUtil
+
+@main
+struct mint_update: ParsableCommand {
+    static let configuration: CommandConfiguration = .init(
+        commandName: "mint-update",
+        abstract: "Updates version of the package defined in the `Mintfile`",
+        shouldDisplay: true,
+        helpNames: [.long, .short]
+    )
+
+    @ArgumentParser.Option(
+        help: "Package Name"
+    )
+    var name: String?
+
+    @ArgumentParser.Flag(
+        name: .customLong("all"),
+        help: "Update All Packages"
+    )
+    var shouldUpdateAll: Bool = false
+
+    @ArgumentParser.Option(
+        name: [.customShort("m"), .customLong("mintfile")],
+        help: "Custom path to a Mintfile."
+    )
+    var mintFile: String = "Mintfile"
+
+    @ArgumentParser.Flag(
+        name: .customLong("prerelease"),
+        help: "Use the Prerelease version. (alpha, beta, ...)"
+    )
+    var usePrerelease: Bool = false
+
+    mutating func run() throws {
+        let mint = Mint(
+            path: mintPath,
+            linkPath: linkPath,
+            mintFilePath: .init(mintFile)
+        )
+
+        if shouldUpdateAll {
+            try mint.updateAll(usePrerelease: usePrerelease)
+        } else if let name {
+            try mint.update(name, usePrerelease: usePrerelease)
+        } else {
+            print(
+                Self.helpMessage()
+            )
+            throw "Please specify package name"
+        }
+    }
+}
+
+extension mint_update {
+    var mintPath: Path {
+        var mintPath: Path = "~/.mint"
+        if let path = ProcessInfo.processInfo.environment["MINT_PATH"], !path.isEmpty {
+            mintPath = Path(path)
+        }
+        return mintPath
+    }
+
+    var linkPath: Path {
+        var linkPath: Path = "~/.mint/bin"
+        if let path = ProcessInfo.processInfo.environment["MINT_LINK_PATH"], !path.isEmpty {
+            linkPath = Path(path)
+        }
+        return linkPath
+    }
+}

--- a/Sources/mint-update/mint_update.swift
+++ b/Sources/mint-update/mint_update.swift
@@ -31,7 +31,7 @@ struct mint_update: ParsableCommand {
     var mintFile: String = "Mintfile"
 
     @ArgumentParser.Flag(
-        name: .customLong("prerelease"),
+        name: .customLong("use-prerelease"),
         help: "Use the Prerelease version. (alpha, beta, ...)"
     )
     var usePrerelease: Bool = false

--- a/Tests/MintUpdateTests/MintUpdateTests.swift
+++ b/Tests/MintUpdateTests/MintUpdateTests.swift
@@ -1,0 +1,42 @@
+//
+//  MintUpdateTests.swift
+//
+//
+//  Created by p-x9 on 2024/09/18
+//  
+//
+
+import XCTest
+@testable import mint_update
+
+class MintUpdateTests: XCTestCase {
+    func testPrereleaseCheck() {
+        let prereleaseVersions = [
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-beta",
+            "1.0.0-beta.2",
+            "2.1.0-rc.1",
+            "3.0.0-alpha+build123",
+            "2.0.0-rc.3+meta",
+            // not confirmed semantic versioning
+            "1.0.0.alpha"
+        ]
+
+        let notPrereleaseVersions = [
+            "1.0.0",
+            "1.0.1",
+            "2.0.0",
+            "2.1.0",
+            "3.0.0",
+        ]
+
+        for v in prereleaseVersions {
+            XCTAssertTrue(v.isPrerelease, "\(v)")
+        }
+
+        for v in notPrereleaseVersions {
+            XCTAssertFalse(v.isPrerelease)
+        }
+    }
+}

--- a/Tests/MintUpdateTests/MintUpdateTests.swift
+++ b/Tests/MintUpdateTests/MintUpdateTests.swift
@@ -36,7 +36,7 @@ class MintUpdateTests: XCTestCase {
         }
 
         for v in notPrereleaseVersions {
-            XCTAssertFalse(v.isPrerelease)
+            XCTAssertFalse(v.isPrerelease, "\(v)")
         }
     }
 }


### PR DESCRIPTION
The current implementation was updated to the latest, including prerelease versions such as beta.
In this pull request, the prerelease version is no longer used by default.
It is possible to use the prerelease version by specifying the `--use-prerelease` option.