### PR TITLE
Exclude non-version tags

### DIFF
--- a/Sources/MintUpdateUtil/Mint+.swift
+++ b/Sources/MintUpdateUtil/Mint+.swift
@@ -110,7 +110,7 @@ extension Mint {
             bash: "git ls-remote --tags --refs \(package.gitPath)"
         )
         let tagReferences = tagOutput.stdout
-        var tags = tagReferences
+        let tags = tagReferences
             .split(separator: "\n")
             .map {
                 String(
@@ -121,12 +121,24 @@ extension Mint {
                 )
             }
 
+        var tagsMap: [String: String] = .init(
+            uniqueKeysWithValues: tags.compactMap {
+                if let normalized = $0.normalizedVersion {
+                    return ($0, normalized)
+                }
+                return nil
+            }
+        )
+
         if !usePrerelease {
-            tags = tags.filter { !$0.isPrerelease }
+            tagsMap = tagsMap.filter { !$1.isPrerelease }
         }
 
-        tags.sort { $0.compare($1, options: .numeric) == .orderedAscending }
-
-        return tags.last
+        return tagsMap
+            .sorted {
+                $0.value.compare($1.value, options: .numeric) == .orderedAscending
+            }
+            .last?
+            .value
     }
 }

--- a/Sources/MintUpdateUtil/String+.swift
+++ b/Sources/MintUpdateUtil/String+.swift
@@ -44,6 +44,25 @@ extension String {
     }
 }
 
+extension String {
+    static let releasedVersionPattern = #"^\d+\.\d+\.\d"#
+    static var releasedVersionRegex: NSRegularExpression {
+        try! .init(pattern: releasedVersionPattern)
+    }
+
+    package var releasedVersion: String? {
+        let range = NSRange(startIndex ..< endIndex, in: self)
+        guard let result = Self.releasedVersionRegex
+            .firstMatch(in: self, options: [], range: range) else {
+            return nil
+        }
+        if let matchedRange = Range(result.range, in: self) {
+            return String(self[matchedRange])
+        }
+        return nil
+    }
+}
+
 extension String: LocalizedError {
     public var errorDescription: String? {
         self

--- a/Sources/MintUpdateUtil/String+.swift
+++ b/Sources/MintUpdateUtil/String+.swift
@@ -9,6 +9,29 @@
 import Foundation
 
 extension String {
+    static let versionPattern = #"^\d+\.\d+\.\d+[A-Za-z0-9.+-]*$"#
+    static var versionRegex: NSRegularExpression {
+        try! .init(pattern: versionPattern)
+    }
+
+    /// Normalised version strings for semantic versioning rules.
+    /// (This is not the case for the prerelease and build metadata parts.)
+    ///
+    /// Occasionally, there are cases where the version is prefixed with a ‘v’.
+    ///    This does not conform to the rules of semantic versioning.
+    package var normalizedVersion: String? {
+        var string = self
+        if string.starts(with: "v") { string.removeFirst() }
+        let range = NSRange(string.startIndex ..< string.endIndex, in: string)
+        if Self.versionRegex
+            .firstMatch(in: string, options: [], range: range) != nil {
+            return string
+        }
+        return nil
+    }
+}
+
+extension String {
     static let prereleasePattern = #"^\d+\.\d+\.\d+[.+-][A-Za-z0-9.+-]+$"#
     static var prereleaseRegex: NSRegularExpression {
         try! .init(pattern: prereleasePattern)

--- a/Tests/MintUpdateTests/MintUpdateTests.swift
+++ b/Tests/MintUpdateTests/MintUpdateTests.swift
@@ -7,9 +7,49 @@
 //
 
 import XCTest
-@testable import mint_update
+@testable import MintUpdateUtil
+import MintKit
 
 class MintUpdateTests: XCTestCase {
+    func testNormalizedVersion() {
+        let sameVersions = [
+            "1.0.0-alpha",
+            "1.0.0-alpha.1",
+            "1.0.0-beta",
+            "1.0.0-beta.2",
+            "2.1.0-rc.1",
+            "3.0.0-alpha+build123",
+            "2.0.0-rc.3+meta",
+            // not confirmed semantic versioning
+            "1.0.0.alpha"
+        ]
+
+        let invalidVersions = [
+            "",
+            "main",
+        ]
+
+        let versions = [
+            "v1.0.0": "1.0.0",
+            "v1.0.0-alpha": "1.0.0-alpha",
+            "v1.0.0-alpha.1": "1.0.0-alpha.1",
+            "v3.0.0-alpha+build123": "3.0.0-alpha+build123",
+        ]
+
+        for v in sameVersions {
+            XCTAssertEqual(v, v.normalizedVersion)
+        }
+
+        for v in invalidVersions {
+            XCTAssertNil(v.normalizedVersion)
+        }
+
+        for v in versions {
+            XCTAssertEqual(v.key.normalizedVersion, v.value)
+        }
+
+    }
+
     func testPrereleaseCheck() {
         let prereleaseVersions = [
             "1.0.0-alpha",
@@ -38,5 +78,54 @@ class MintUpdateTests: XCTestCase {
         for v in notPrereleaseVersions {
             XCTAssertFalse(v.isPrerelease, "\(v)")
         }
+    }
+
+    func testFindVersion() throws {
+        let dummy = Mint(path: .home, linkPath: .home)
+
+        var tags = [
+            "0.0.1",
+            "1.0.0",
+            "test",
+            "2.0.0-rc.3+meta",
+            "2.0.0"
+        ]
+
+        var map = dummy._tagVersionsMap(of: tags)
+
+        XCTAssertEqual(
+            dummy._findLatestVersion(
+                from: map,
+                usePrerelease: true
+            ),
+            "2.0.0"
+        )
+
+        XCTAssertEqual(
+            dummy._findLatestVersion(
+                from: map,
+                usePrerelease: false
+            ),
+            "2.0.0"
+        )
+
+        tags.append("3.0.0-alpha")
+        map = dummy._tagVersionsMap(of: tags)
+
+        XCTAssertEqual(
+            dummy._findLatestVersion(
+                from: map,
+                usePrerelease: true
+            ),
+            "3.0.0-alpha"
+        )
+
+        XCTAssertEqual(
+            dummy._findLatestVersion(
+                from: map,
+                usePrerelease: false
+            ),
+            "2.0.0"
+        )
     }
 }


### PR DESCRIPTION
There are cases where simple strings other than version are used for git tags.
When these are included and sorted, a tag with such a string is always used as the latest version.